### PR TITLE
fix: Prevent new tab opening on table row click

### DIFF
--- a/nerdlets/shared/components/breakdown.js
+++ b/nerdlets/shared/components/breakdown.js
@@ -6,13 +6,19 @@ import {
   Grid,
   GridItem,
   HeadingText,
-  TableChart,
+  NrqlQuery,
   Spinner,
   NerdGraphQuery,
   navigation,
   Toast,
   PlatformStateContext,
-  NerdletStateContext
+  NerdletStateContext,
+  Table,
+  TableHeader,
+  TableRow,
+  TableHeaderCell,
+  TableRowCell,
+  Icon
 } from 'nr1';
 
 import { get } from 'lodash';
@@ -35,6 +41,13 @@ export default class Breakdown extends React.PureComponent {
 
   constructor(props) {
     super(props);
+
+    this.state = {
+      sortingType: TableHeaderCell.SORTING_TYPE.ASCENDING,
+      sortedColumn: 0
+    };
+
+    this.toggleSortingType = this.toggleSortingType.bind(this);
   }
 
   _openDetails(pageUrl) {
@@ -46,6 +59,132 @@ export default class Breakdown extends React.PureComponent {
         entityGuid: entity.guid
       }
     });
+  }
+
+  toggleSortingType(sortedColumn) {
+    this.setState(prevState => {
+      return {
+        sortedColumn: sortedColumn,
+        sortingType:
+          prevState.sortingType === TableHeaderCell.SORTING_TYPE.DESCENDING
+            ? TableHeaderCell.SORTING_TYPE.ASCENDING
+            : TableHeaderCell.SORTING_TYPE.DESCENDING
+      };
+    });
+  }
+
+  renderTopPeformanceTableItems(data) {
+    return data.map((item, index) => {
+      const pageUrl = item.name;
+      const pageCount = item.results[0].count;
+      const averageDuration = item.results[1].average.toFixed(2);
+      const apdex = item.results[2].score.toFixed(2);
+
+      const output = {
+        pageUrl,
+        pageCount,
+        averageDuration,
+        apdex,
+        columnIndex: index
+      };
+
+      return output;
+    });
+  }
+
+  renderTopPerformanceTable(data) {
+    return (
+      <Table
+        className="performance-improvement-table"
+        spacingType={[Table.SPACING_TYPE.LARGE, Table.SPACING_TYPE.NONE]}
+        items={this.renderTopPeformanceTableItems(data.facets)}
+      >
+        <TableHeader>
+          <TableHeaderCell
+            value={({ item }) => item.pageUrl}
+            sortable
+            onClick={(event, sortingData, sortedColumn = 0) => {
+              this.toggleSortingType(sortedColumn);
+            }}
+            sortingOrder={0}
+            sortingType={
+              this.state.sortedColumn === 0 ? this.state.sortingType : undefined
+            }
+          >
+            Page URL
+          </TableHeaderCell>
+          <TableHeaderCell
+            alignmentType={TableRowCell.ALIGNMENT_TYPE.RIGHT}
+            width="130px"
+            value={({ item }) => item.pageCount}
+            sortable
+            onClick={(event, sortingData, sortedColumn = 1) => {
+              this.toggleSortingType(sortedColumn);
+            }}
+            sortingOrder={1}
+            sortingType={
+              this.state.sortedColumn === 1 ? this.state.sortingType : undefined
+            }
+          >
+            Page Count
+          </TableHeaderCell>
+          <TableHeaderCell
+            alignmentType={TableRowCell.ALIGNMENT_TYPE.RIGHT}
+            width="130px"
+            value={({ item }) => item.averageDuration}
+            sortable
+            onClick={(event, sortingData, sortedColumn = 2) => {
+              this.toggleSortingType(sortedColumn);
+            }}
+            sortingOrder={2}
+            sortingType={
+              this.state.sortedColumn === 2 ? this.state.sortingType : undefined
+            }
+          >
+            Avg. duration
+          </TableHeaderCell>
+          <TableHeaderCell
+            alignmentType={TableRowCell.ALIGNMENT_TYPE.RIGHT}
+            width="80px"
+            value={({ item }) => item.apdex}
+            sortable
+            onClick={(event, sortingData, sortedColumn = 3) => {
+              this.toggleSortingType(sortedColumn);
+            }}
+            sortingOrder={3}
+            sortingType={
+              this.state.sortedColumn === 3 ? this.state.sortingType : undefined
+            }
+          >
+            Apdex
+          </TableHeaderCell>
+        </TableHeader>
+        {({ item }) => (
+          <TableRow
+            actions={[
+              {
+                iconType: Icon.TYPE.INTERFACE__INFO__INFO,
+                label: 'View details for this page',
+                onClick: () => this._openDetails(item.pageUrl)
+              }
+            ]}
+          >
+            <TableRowCell onClick={() => this._openDetails(item.pageUrl)}>
+              {item.pageUrl}
+            </TableRowCell>
+            <TableRowCell alignmentType={TableRowCell.ALIGNMENT_TYPE.RIGHT}>
+              {item.pageCount}
+            </TableRowCell>
+            <TableRowCell alignmentType={TableRowCell.ALIGNMENT_TYPE.RIGHT}>
+              {item.averageDuration}
+            </TableRowCell>
+            <TableRowCell alignmentType={TableRowCell.ALIGNMENT_TYPE.RIGHT}>
+              {item.apdex}
+            </TableRowCell>
+          </TableRow>
+        )}
+      </Table>
+    );
   }
 
   render() {
@@ -153,14 +292,19 @@ export default class Breakdown extends React.PureComponent {
                             <HeadingText type={HeadingText.TYPE.HEADING3}>
                               Top Performance Improvement Targets
                             </HeadingText>
-                            <TableChart
-                              className="tableChart"
+                            <NrqlQuery
                               accountId={entity.accountId}
+                              formatType={NrqlQuery.FORMAT_TYPE.RAW}
                               query={`FROM PageView SELECT count(*) as 'Page Count', average(duration) as 'Avg. Duration', apdex(duration, ${apdexTarget}) as 'Apdex' WHERE appName='${entity.name}' AND nr.apdexPerfZone in ('F', 'T') FACET pageUrl LIMIT 100 ${timePickerRange}`}
-                              onClickTable={(...args) => {
-                                this._openDetails(args[1].pageUrl);
+                            >
+                              {({ data }) => {
+                                if (data) {
+                                  return this.renderTopPerformanceTable(data);
+                                } else {
+                                  return '';
+                                }
                               }}
-                            />
+                            </NrqlQuery>
                           </GridItem>
                         )}
                       </Grid>

--- a/nerdlets/shared/components/components.scss
+++ b/nerdlets/shared/components/components.scss
@@ -265,3 +265,11 @@
   color: #2a3434;
   font-weight: bold;
 }
+
+.performance-improvement-table {
+  max-height: 500px;
+  height: inherit;
+  border: 1px solid #e3e4e4;
+  box-shadow: 0 1px 3px 0 rgba(203, 226, 226, 0.34);
+  border-radius: 3px;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nr1-browser-analyzer",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
### Overview
This PR when merged, will close newrelic#27, which describes an issue where when you click a URL in the top performance table a new tab to that URL would be opened up in the browser (instead of just opening up a modal for more details on that row). This behavior is fixed with this commit.

#### What's changed?
- Fixed issue #27
- Replaced the old platform table with [the new version](https://developer.newrelic.com/client-side-sdk/index.html#components/Table) recently released.