### PR TITLE
fix: uses GH API to disable/enable branch protection so committing works

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,8 @@ on:
     types: [semantic-release]
 
 env:
-  THIRD_PARTY_GIT_AUTHOR_EMAIL: jeveland@newrelic.com
-  THIRD_PARTY_GIT_AUTHOR_NAME: jbeveland27
+  THIRD_PARTY_GIT_AUTHOR_EMAIL: opensource+newrelicbot@newrelic.com
+  THIRD_PARTY_GIT_AUTHOR_NAME: Newrelicbot
 
 jobs:
   job-checkout-and-build:
@@ -107,16 +107,58 @@ jobs:
             echo "No change in package.json, not regenerating third-party notices"
           fi
       
+      - name: Temporarily disable "required_pull_request_reviews" branch protection
+        id: disable-branch-protection
+        if: always()
+        uses: actions/github-script@v1
+        with:
+          github-token: ${{ secrets.NEWRELIC_BOT_TOKEN }}
+          previews: luke-cage-preview
+          script: |
+            const result = await github.repos.updateBranchProtection({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              branch: 'master',
+              required_status_checks: null,
+              restrictions: null,
+              enforce_admins: null,
+              required_pull_request_reviews: null
+            })
+            console.log("Result:", result)
+      
       - name: Push Commit
         if: steps.generate-notices.outputs.commit == 'true'
-        uses: ad-m/github-push-action@v0.5.0
+        uses: ad-m/github-push-action@v0.6.0
         with:
           github_token: ${{ secrets.NEWRELIC_BOT_TOKEN }}
+      
+      - name: Re-enable "required_pull_request_reviews" branch protection
+        id: enable-branch-protection
+        if: always()
+        uses: actions/github-script@v1
+        with:
+          github-token: ${{ secrets.NEWRELIC_BOT_TOKEN }}
+          previews: luke-cage-preview
+          script: |
+            const result = await github.repos.updateBranchProtection({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              branch: 'master',
+              required_status_checks: null,
+              restrictions: null,
+              enforce_admins: null,
+              required_pull_request_reviews: {
+                required_approving_review_count: 1
+              }
+            })
+            console.log("Result:", result)
 
   job-generate-release:
     runs-on: ubuntu-latest
     needs: [job-checkout-and-build, job-generate-third-party-notices]
     steps:
+      # Checkout ref: master because previous job committed third_party_notices and
+      # we need to checkout master to pick up that commit
       - name: Checkout repo
         uses: actions/checkout@v2
         with:
@@ -141,7 +183,47 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Temporarily disable "required_pull_request_reviews" branch protection
+        id: disable-branch-protection
+        if: always()
+        uses: actions/github-script@v1
+        with:
+          github-token: ${{ secrets.NEWRELIC_BOT_TOKEN }}
+          previews: luke-cage-preview
+          script: |
+            const result = await github.repos.updateBranchProtection({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              branch: 'master',
+              required_status_checks: null,
+              restrictions: null,
+              enforce_admins: null,
+              required_pull_request_reviews: null
+            })
+            console.log("Result:", result)
+
       - name: Run semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.NEWRELIC_BOT_TOKEN }}
         run: npx semantic-release
+
+      - name: Re-enable "required_pull_request_reviews" branch protection
+        id: enable-branch-protection
+        if: always()
+        uses: actions/github-script@v1
+        with:
+          github-token: ${{ secrets.NEWRELIC_BOT_TOKEN }}
+          previews: luke-cage-preview
+          script: |
+            const result = await github.repos.updateBranchProtection({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              branch: 'master',
+              required_status_checks: null,
+              restrictions: null,
+              enforce_admins: null,
+              required_pull_request_reviews: {
+                required_approving_review_count: 1
+              }
+            })
+            console.log("Result:", result)


### PR DESCRIPTION
Context: Supplying a repo Admin's Personal Access Token with the correct permissions _should_ allow them to push commits from within a GitHub Action (as is the case when the third_party_notices are generated). However, I've not been able to get this to work. This was also a problem when running semantic-release. Basically, supplying a personal access token to override the github_token seems broken when branch protection is enabled.

In light of that, this change modifies the workflow to utilize the GitHub API via [actions/github-script](https://github.com/actions/github-script) to disable/enable branch protection. Basically it disables branch protection, performs the commit, then re-enables the same settings that were present before.