### PR TITLE
fix: Error opening page details

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.7.1](https://github.com/newrelic/nr1-browser-analyzer/compare/v1.7.0...v1.7.1) (2025-03-24)
+
+
+### Bug Fixes
+
+* GraphQL response format ( [76135c1](https://github.com/newrelic/nr1-browser-analyzer/commit/76135c1e32461234056fbe9fd3442da80985aac8))
+
 # [1.7.0](https://github.com/newrelic/nr1-browser-analyzer/compare/v1.6.2...v1.7.0) (2024-02-16)
 
 

--- a/nerdlets/shared/components/stat-utils.js
+++ b/nerdlets/shared/components/stat-utils.js
@@ -46,7 +46,7 @@ function buildSatisfied(cohorts, satisfied, bounceRate) {
   obj.raw = {};
   const SbounceRate = !bounceRate
     ? null
-    : bounceRate.results.find((r) => r.facet === 'S');
+    : bounceRate.rawResponse.facets.find((r) => r.name === 'S');
   const S =
     cohorts && cohorts.results
       ? cohorts.results.find((c) => c.facet === 'S')
@@ -60,7 +60,7 @@ function buildTolerated(cohorts, tolerated, bounceRate) {
   obj.raw = {};
   const TbounceRate = !bounceRate
     ? null
-    : bounceRate.results.find((r) => r.facet === 'T');
+    : bounceRate.rawResponse.facets.find((r) => r.name === 'T');
   const T =
     cohorts && cohorts.results
       ? cohorts.results.find((c) => c.facet === 'T')
@@ -74,7 +74,7 @@ function buildFrustrated(cohorts, frustrated, bounceRate) {
   obj.raw = {};
   const FbounceRate = !bounceRate
     ? null
-    : bounceRate.results.find((r) => r.facet === 'F');
+    : bounceRate.rawResponse.facets.find((r) => r.name === 'F');
   const F =
     cohorts && cohorts.results
       ? cohorts.results.find((c) => c.facet === 'F')
@@ -102,11 +102,15 @@ function fillObject(obj, sample, cohort, bounceCohort) {
     obj.bounces = calcBounces(sample.results);
   }
 
-  if (bounceCohort) {
-    obj.raw.bounceCohort = { ...bounceCohort };
-    obj.bounces = bounceCohort.steps[0] - bounceCohort.steps[1];
-    obj.totalSamples = bounceCohort.steps[0];
+  if (bounceCohort && bounceCohort.results && bounceCohort.results.length > 0) {
+    bounceCohort = bounceCohort.results[0];
+    if (bounceCohort.steps) {
+      obj.raw.bounceCohort = { ...bounceCohort };
+      obj.bounces = bounceCohort.steps[0] - bounceCohort.steps[1];
+      obj.totalSamples = bounceCohort.steps[0];
+    }
   }
+  
   return obj;
 }
 

--- a/nerdlets/shared/nrql-factory/index.js
+++ b/nerdlets/shared/nrql-factory/index.js
@@ -301,6 +301,7 @@ class SPAFactory extends NrqlFactory {
                   targetUrl ? `WHERE targetUrl != '${targetUrl}'` : ''
                 } as 'nextPage') ${facetCaseStmt}") {
               results
+              rawResponse
           }`
               : ''
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nr1-browser-analyzer",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nr1-browser-analyzer",
-      "version": "1.6.1",
+      "version": "1.7.1",
       "dependencies": {
         "@newrelic/nr-labs-components": "^1.21.2",
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "nr1-browser-analyzer",
   "description": "NR1 Nerdpack business value analysis of Browser data.",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "bugs": {
     "email": "opensource+nr1-browser-analyzer@newrelic.com"
   },


### PR DESCRIPTION
### Details

The response format coming from the NerdGraph API  changed (somehow), and the code crashes because is accessing properties which doesn't exist anymore in the `results` response. To fix it, we changed the GraphQL request, to ask for the `rawResponse` response, where the required information is present.